### PR TITLE
Add support for kernel up to 5.x

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 #MAKE_OPTS = -C /usr/src/linux SUBDIRS=`pwd` V=1
 #MAKE_OPTS = -C /usr/src/linux SUBDIRS=`pwd`
-MAKE_OPTS = -C /usr/src/linux-`uname -r` SUBDIRS=`pwd`
+MAKE_OPTS = -C /usr/src/linux-`uname -r` M=`pwd` SUBDIRS=`pwd`
 PATH_SYSFS := $(shell find /sys/ -name get_icons | sed 's/\/get_icons//')
 #EXTRA_CFLAGS += -DDEBUG -O0 -g -Wall
 SHELL := $(shell which bash)

--- a/yealink.c
+++ b/yealink.c
@@ -107,21 +107,6 @@
 #define YEALINK_COMMAND_DELAY_G2	25	/* in [ms] */
 
 /* Make sure we have the following macros (independent of kernel versions) */
-#ifndef dev_dbg
-#define dev_dbg(dev, format, arg...) printk(KERN_DEBUG KBUILD_MODNAME ": " \
-	format "\n" , ## arg)
-#endif
-
-#ifndef dev_err
-#define dev_err(dev, format, arg...) printk(KERN_ERR KBUILD_MODNAME ": " \
-	format "\n" , ## arg)
-#endif
-
-#ifndef dev_warn
-#define dev_warn(dev, format, arg...) printk(KERN_WARNING KBUILD_MODNAME ": " \
-	format "\n" , ## arg)
-#endif
-
 #ifndef dev_info
 #define dev_info(dev, format, arg...) printk(KERN_INFO KBUILD_MODNAME ": " \
 	format "\n" , ## arg)

--- a/yealink.c
+++ b/yealink.c
@@ -64,6 +64,8 @@
  *                      up to at least 3.14.
  *   20211013 Slavek	Update code for new timer API.
  *                      This allows to build with the kernel >= 4.15.
+ *   20211014 Slavek	Use macro sizeof_field instead of FIELD_SIZEOF.
+ *                      This allows to build with the kernel >= 5.5.
  *
  * TODO:
  *   - P1KH: Better understand how the ring notes have to be set up.
@@ -88,7 +90,7 @@
 #error "Need kernel version 2.6.18 or higher"
 #endif
 
-#define DRIVER_VERSION	"20211013"
+#define DRIVER_VERSION	"20211014"
 #define DRIVER_AUTHOR	"Thomas Reitmayr, Henk Vergonet"
 #define DRIVER_DESC	"Yealink phone driver"
 
@@ -112,6 +114,10 @@
 #ifndef dev_info
 #define dev_info(dev, format, arg...) printk(KERN_INFO KBUILD_MODNAME ": " \
 	format "\n" , ## arg)
+#endif
+
+#ifndef sizeof_field
+#define sizeof_field FIELD_SIZEOF
 #endif
 
 /* for in-depth debugging */
@@ -652,7 +658,7 @@ static int check_feature_p1k(size_t offset)
 {
 	return  (offset >= offsetof(struct yld_status, lcd) &&
 		 offset < offsetof(struct yld_status, lcd) +
-			  FIELD_SIZEOF(struct yld_status, lcd)) ||
+			  sizeof_field(struct yld_status, lcd)) ||
 		offset == offsetof(struct yld_status, led) ||
 		offset == offsetof(struct yld_status, keynum) ||
 		offset == offsetof(struct yld_status, ringvol) ||
@@ -664,7 +670,7 @@ static int check_feature_p1kh(size_t offset)
 {
 	return  (offset >= offsetof(struct yld_status, lcd) &&
 		 offset < offsetof(struct yld_status, lcd) +
-			  FIELD_SIZEOF(struct yld_status, lcd)) ||
+			  sizeof_field(struct yld_status, lcd)) ||
 		offset == offsetof(struct yld_status, led) ||
 		offset == offsetof(struct yld_status, ringvol) ||
 		offset == offsetof(struct yld_status, ringnote_mod) ||
@@ -675,7 +681,7 @@ static int check_feature_p4k(size_t offset)
 {
 	return  (offset >= offsetof(struct yld_status, lcd) &&
 		 offset < offsetof(struct yld_status, lcd) +
-			  FIELD_SIZEOF(struct yld_status, lcd)) ||
+			  sizeof_field(struct yld_status, lcd)) ||
 		/*offset == offsetof(struct yld_status, led) ||*/
 		offset == offsetof(struct yld_status, backlight) ||
 		offset == offsetof(struct yld_status, speaker) ||

--- a/yealink.h
+++ b/yealink.h
@@ -36,7 +36,7 @@ struct yld_ctl_packet_g1 {
 } __attribute__ ((packed));
 
 #define USB_PKT_LEN_G1		sizeof(struct yld_ctl_packet_g1)
-#define USB_PKT_DATA_LEN_G1	FIELD_SIZEOF(struct yld_ctl_packet_g1, data)
+#define USB_PKT_DATA_LEN_G1	sizeof_field(struct yld_ctl_packet_g1, data)
 
 /* "Generation 2" models use 8 byte packets */
 
@@ -47,7 +47,7 @@ struct yld_ctl_packet_g2 {
 } __attribute__ ((packed));
 
 #define USB_PKT_LEN_G2		sizeof(struct yld_ctl_packet_g2)
-#define USB_PKT_DATA_LEN_G2	FIELD_SIZEOF(struct yld_ctl_packet_g2, data)
+#define USB_PKT_DATA_LEN_G2	sizeof_field(struct yld_ctl_packet_g2, data)
 
 union yld_ctl_packet {
 	u8	cmd;		/* command code is always the first byte */


### PR DESCRIPTION
Because I use the module virtually every day, I needed to solve the module compatibility with newer kernel versions.

Patches addresses the timers API change (kernel 4.15), changes related to building (kernel 5.3) and cleaning of macros for field_sizeof (kernel 5.5). I tested successfully to build up to 5.14.x.

Please revise and if everything seems ok to merge.